### PR TITLE
Mat File Reading

### DIFF
--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -1,2 +1,10 @@
+include(FetchContent)
+FetchContent_Declare(
+    suitesparse_matrix
+    GIT_REPOSITORY git@github.com:kenmalik/suitesparse-matrix.git
+    GIT_TAG main
+)
+FetchContent_MakeAvailable(suitesparse_matrix)
+
 add_executable(example "example.cpp")
-target_link_libraries(example PRIVATE dr_bcg_cpu)
+target_link_libraries(example PRIVATE dr_bcg_cpu suitesparse_matrix)

--- a/examples/example.cpp
+++ b/examples/example.cpp
@@ -1,5 +1,6 @@
 #include "dr_bcg_cpu/dr_bcg_cpu.h"
 #include <iostream>
+#include <suitesparse_matrix.h>
 
 void verify(const SpMat &A, const Mat &X, const Mat &B) {
     std::cout << "Verification that A * X = B" << std::endl;
@@ -9,25 +10,33 @@ void verify(const SpMat &A, const Mat &X, const Mat &B) {
 }
 
 int main(int argc, char *argv[]) {
-    constexpr int n = 8;
+    SuiteSparseMatrix ssm(argv[1]);
+    const int n = ssm.rows();
     constexpr int s = 4;
 
     SpMat A(n, n);
     std::vector<T> triplet_list(n);
-    for (int i = 0; i < n; i++) {
-        T t{i, i, 1};
-        triplet_list.push_back(t);
+
+    for (int k = 0; k < ssm.nnz(); ++k) {
+        // Find the column for the k-th non-zero element
+        int col = 0;
+        while (col < n && ssm.jc()[col + 1] <= k) {
+            col++;
+        }
+        triplet_list.push_back({static_cast<int64_t>(ssm.ir()[k]), col,
+                                static_cast<float>(ssm.data()[k])});
     }
     A.setFromTriplets(triplet_list.begin(), triplet_list.end());
 
-    Mat X(n, s);
+    Mat X = Mat::Constant(n, s, 0);
     Mat B = Mat::Constant(n, s, 1);
 
-    std::cout << "A:\n" << A << std::endl;
+    std::cout << "A:\n"
+              << Eigen::MatrixXf(A).format({2, 0, ", ", "\n"}) << std::endl;
     std::cout << "X:\n" << X << std::endl;
     std::cout << "B:\n" << B << std::endl;
 
-    int iterations = dr_bcg_cpu::dr_bcg(A, X, B);
+    int iterations = dr_bcg_cpu::dr_bcg(A, X, B, 0.001);
 
     std::cout << "X Final:\n" << X << std::endl;
     std::cout << "Iterations: " << iterations << std::endl;

--- a/examples/example.cpp
+++ b/examples/example.cpp
@@ -9,10 +9,8 @@ void verify(const SpMat &A, const Mat &X, const Mat &B) {
     std::cout << "B:\n" << B << std::endl;
 }
 
-int main(int argc, char *argv[]) {
-    SuiteSparseMatrix ssm(argv[1]);
+SpMat sparse_matlab_to_eigen(SuiteSparseMatrix &ssm) {
     const int n = ssm.rows();
-    constexpr int s = 4;
 
     SpMat A(n, n);
     std::vector<T> triplet_list(n);
@@ -28,6 +26,15 @@ int main(int argc, char *argv[]) {
     }
     A.setFromTriplets(triplet_list.begin(), triplet_list.end());
 
+    return A;
+}
+
+int main(int argc, char *argv[]) {
+    SuiteSparseMatrix ssm(argv[1]);
+    const int n = ssm.rows();
+    constexpr int s = 4;
+
+    SpMat A = sparse_matlab_to_eigen(ssm);
     Mat X = Mat::Constant(n, s, 0);
     Mat B = Mat::Constant(n, s, 1);
 

--- a/include/dr_bcg_cpu/dr_bcg_cpu.h
+++ b/include/dr_bcg_cpu/dr_bcg_cpu.h
@@ -5,10 +5,11 @@
 #include <limits>
 
 using CalcType = float;
+using IndexType = int64_t;
 
 using Mat = Eigen::MatrixXf;
-using SpMat = Eigen::SparseMatrix<CalcType>;
-using T = Eigen::Triplet<CalcType>;
+using SpMat = Eigen::SparseMatrix<CalcType, Eigen::ColMajor, IndexType>;
+using T = Eigen::Triplet<CalcType, IndexType>;
 
 namespace dr_bcg_cpu {
 int dr_bcg(const SpMat &A, Mat &X, const Mat &B,

--- a/lib/dr_bcg_cpu.cpp
+++ b/lib/dr_bcg_cpu.cpp
@@ -1,51 +1,79 @@
 #include "dr_bcg_cpu/dr_bcg_cpu.h"
 #include <Eigen/QR>
+#include <cmath>
+#include <string>
 
-/*
-function [X_final, iterations] = DR_BCG(A, B, X, tol, maxit)
-    iterations = 0;
-    R = B - A * X;
-    [w, sigma] = qr(R,'econ');
-    s = w;
+#define CHECK_NAN(mat, iteration)                                              \
+    do {                                                                       \
+        check_nan(mat,                                                         \
+                  "iteration " + std::to_string(iteration) + ": " + #mat);     \
+    } while (0);
 
-    for k = 1:maxit
-        iterations = iterations + 1;
-        xi = (s' * A * s)^-1;
-        X = X + s * xi * sigma;
-        if (norm(B(:,1) - A * X(:,1)) / norm(B(:,1))) < tol
-            break
-        else
-            [w, zeta] = qr(w - A * s * xi,'econ');
-            s = w + s * zeta';
-            sigma = zeta * sigma;
-        end
-    end
-    X_final = X;
-end
- */
+#ifdef DEBUG
+
+#include <iostream>
+#include <sstream>
+#include <stdexcept>
+
+void check_nan(const Mat &mat, const std::string step) {
+    for (int i = 0; i < mat.rows(); ++i) {
+        for (int j = 0; j < mat.cols(); ++j) {
+            if (std::isnan(mat(i, j))) {
+                std::ostringstream oss;
+                oss << "Nan detected after step '" << step << "'\n"
+                    << mat << std::endl;
+                throw std::runtime_error(oss.str());
+            }
+        }
+    }
+}
+
+#else
+
+void check_nan(const Mat &mat, const std::string step) {};
+
+#endif
+
+inline void reduced_QR(const Mat &A, Mat &Q, Mat &R) {
+    const int m = A.rows();
+    const int n = A.cols();
+    Eigen::HouseholderQR<Mat> qr(A);
+    Q = qr.householderQ() * Mat::Identity(m, n);
+    R = qr.matrixQR().topLeftCorner(n, n).triangularView<Eigen::Upper>();
+}
 
 int dr_bcg_cpu::dr_bcg(const SpMat &A, Mat &X, const Mat &B, float tolerance,
-                        int max_iterations) {
+                       int max_iterations) {
     int iterations = 0;
 
     Mat R = B - A * X;
-    Eigen::HouseholderQR<Mat> qr(R);
-    Mat w = qr.householderQ();
-    Mat sigma = qr.matrixQR().triangularView<Eigen::Upper>();
+
+    Mat w, sigma;
+    reduced_QR(R, w, sigma);
+
     Mat s = w;
 
     for (iterations = 0; iterations < max_iterations; ++iterations) {
         Mat xi = (s.transpose() * A * s).inverse();
+        CHECK_NAN(xi, iterations);
+
         X = X + s * xi * sigma;
+        CHECK_NAN(X, iterations);
+
         if ((B.col(0) - A * X.col(0)).norm() / B.col(0).norm() < tolerance) {
             ++iterations;
             break;
         } else {
-            Eigen::HouseholderQR<Mat> qr(w - A * s * xi);
-            w = qr.householderQ();
-            Mat zeta = qr.matrixQR().triangularView<Eigen::Upper>();
+            Mat zeta;
+            reduced_QR(w - A * s * xi, w, zeta);
+            CHECK_NAN(w, iterations);
+            CHECK_NAN(zeta, iterations);
+
             s = w + s * zeta.transpose();
+            CHECK_NAN(s, iterations);
+
             sigma = zeta * sigma;
+            CHECK_NAN(sigma, iterations);
         }
     }
 


### PR DESCRIPTION
Add code to read `.mat` files to example.

Testing against SuiteSparse matrices revealed that the previous implementation would create `NaN` values due to the use of full QR decomposition rather than reduced QR. This has also been addressed.